### PR TITLE
fix absolute paths to lib directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -274,11 +274,9 @@ __pycache__/
 !**/lib/**
 !**/libs/**
 **/lib/**/project.lock.json
+**/lib/**/bin/
+**/lib/**/obj/
 
 # Allow .sdf files in app_data
 !**/App_Data/*.sdf
 Brighter/Examples/tasklist/Data
-bin
-/Brighter/lib/nUnitShouldAdapter/bin
-/Brighter/lib/nUnitShouldAdapter/obj
-/Brighter/lib/NUnit.Specifications.NUnit3.coreCLR/obj


### PR DESCRIPTION
Because of the absolute paths starting with '/Brighter' some of the lib dirs kept popping up as untracked. Changed the lib section to fix this.