### PR TITLE
Interpreter component.update

### DIFF
--- a/paramore.brighter.commandprocessor/Interpreter.cs
+++ b/paramore.brighter.commandprocessor/Interpreter.cs
@@ -16,7 +16,7 @@
 Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the �Software�), to deal
+of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is

--- a/paramore.brighter.commandprocessor/Interpreter.cs
+++ b/paramore.brighter.commandprocessor/Interpreter.cs
@@ -13,10 +13,10 @@
 
 #region Licence
 /* The MIT License (MIT)
-Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+Copyright Â© 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the “Software”), to deal
+of this software and associated documentation files (the ï¿½Softwareï¿½), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
@@ -25,7 +25,7 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
@@ -62,7 +62,7 @@ namespace paramore.brighter.commandprocessor
             _asyncHandlerFactory = asyncHandlerFactory;
         }
 
-        internal IEnumerable<RequestHandler<TRequest>> GetHandlers(Type requestType)
+        internal IEnumerable<RequestHandler<TRequest>> GetHandlers()
         {
             return new RequestHandlers<TRequest>(
                 _registry.Get<TRequest>()
@@ -70,7 +70,7 @@ namespace paramore.brighter.commandprocessor
                     .Cast<IHandleRequests<TRequest>>());
         }
 
-        internal IEnumerable<RequestHandlerAsync<TRequest>> GetAsyncHandlers(Type requestType)
+        internal IEnumerable<RequestHandlerAsync<TRequest>> GetAsyncHandlers()
         {
             return new AsyncRequestHandlers<TRequest>(
                 _registry.Get<TRequest>()

--- a/paramore.brighter.commandprocessor/PipelineBuilder.cs
+++ b/paramore.brighter.commandprocessor/PipelineBuilder.cs
@@ -14,10 +14,10 @@
 
 #region Licence
 /* The MIT License (MIT)
-Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
+Copyright Â© 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the “Software”), to deal
+of this software and associated documentation files (the ï¿½Softwareï¿½), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
@@ -26,7 +26,7 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
@@ -71,7 +71,7 @@ namespace paramore.brighter.commandprocessor
 
         public Pipelines<TRequest> Build(IRequestContext requestContext)
         {
-            var handlers = _interpreter.GetHandlers(typeof(TRequest));
+            var handlers = _interpreter.GetHandlers();
 
             var pipelines = new Pipelines<TRequest>();
             handlers.Each(handler => pipelines.Add(BuildPipeline(handler, requestContext)));
@@ -153,7 +153,7 @@ namespace paramore.brighter.commandprocessor
 
         public AsyncPipelines<TRequest> BuildAsync(IRequestContext requestContext, bool continueOnCapturedContext)
         {
-            var handlers = _interpreter.GetAsyncHandlers(typeof(TRequest));
+            var handlers = _interpreter.GetAsyncHandlers();
 
             var pipelines = new AsyncPipelines<TRequest>();
             handlers.Each(handler => pipelines.Add(BuildAsyncPipeline(handler, requestContext, continueOnCapturedContext)));

--- a/paramore.brighter.commandprocessor/PipelineBuilder.cs
+++ b/paramore.brighter.commandprocessor/PipelineBuilder.cs
@@ -17,7 +17,7 @@
 Copyright © 2014 Ian Cooper <ian_hammond_cooper@yahoo.co.uk>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the �Software�), to deal
+of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is


### PR DESCRIPTION
I have removed the unused type parameter (GetHandlers and GetAsyncHandlers methods) since the type is already passed during the creation of the interpreter object (see Generic Send<T> method on CommandProcessor class)