### PR TITLE
PostAsync: async, configure await and cancellation token all the way down to Polly :turtle:

### DIFF
--- a/paramore.brighter.commandprocessor/DefaultPolicy.cs
+++ b/paramore.brighter.commandprocessor/DefaultPolicy.cs
@@ -49,7 +49,8 @@ namespace paramore.brighter.commandprocessor
     /// provide an easy way to do this using the policies that you add to this registry
     /// This is a default implementation of <see cref="IAmAPolicyRegistry"/>
     /// </summary>
-    public class DefaultPolicy : IAmAPolicyRegistry {
+    public class DefaultPolicy : IAmAPolicyRegistry
+    {
         /// <summary>
         /// Gets the default policy of retry once
         /// </summary>
@@ -60,22 +61,29 @@ namespace paramore.brighter.commandprocessor
             switch (policyName)
             {
                 case CommandProcessor.CIRCUITBREAKER:
-                {
                     return Policy.Handle<Exception>().CircuitBreaker(10, new TimeSpan(5000));
-                }
+
+                case CommandProcessor.CIRCUITBREAKERASYNC:
+                    return Policy.Handle<Exception>().CircuitBreakerAsync(10, new TimeSpan(5000));
+
                 case CommandProcessor.RETRYPOLICY:
-                {
                     return Policy.Handle<Exception>().WaitAndRetry(new[]
                     {
                         TimeSpan.FromMilliseconds(50),
                         TimeSpan.FromMilliseconds(100),
                         TimeSpan.FromMilliseconds(150)
                     });
-                }
+
+                case CommandProcessor.RETRYPOLICYASYNC:
+                    return Policy.Handle<Exception>().WaitAndRetryAsync(new[]
+                    {
+                        TimeSpan.FromMilliseconds(50),
+                        TimeSpan.FromMilliseconds(100),
+                        TimeSpan.FromMilliseconds(150)
+                    });
+
                 default:
-                {
                     return Policy.Handle<Exception>().Retry();
-                }
             }
         }
 


### PR DESCRIPTION
Looking over the code I noticed that async Polly isn't invoked correctly. I modified `PostAsync` and `DefaultPolicy` to properly configure and call async policies.

Legal disclaimer: 
The solution currently doesn't compile due to existing issues, but I'm quite confident that this works. Some tweaking may or may not be required 👼 